### PR TITLE
Fix method name in mdns

### DIFF
--- a/src/mdns.rs
+++ b/src/mdns.rs
@@ -52,7 +52,7 @@ pub async fn discover(data: Arc<Mutex<SharedDevices>>) {
                 }
                 println!("Adding device {}", udid);
 
-                lock.add_device(
+                lock.add_network_device(
                     udid,
                     addr,
                     service_name.clone(),


### PR DESCRIPTION
The build with zeroconf feature fails due to a typo in "add_device" method. Correct name is "add_network_device".