### PR TITLE
Fixes to make it able to be packaged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "netmuxd"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "colored",
  "env_logger 0.7.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,8 @@ dependencies = [
 [[package]]
 name = "mdns"
 version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c769962ac75a6ea437f0922b27834bcccd4c013d591383a16ae5731e3ef0f3f3"
 dependencies = [
  "async-std",
  "async-stream",
@@ -1600,6 +1602,7 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 [[package]]
 name = "zeroconf"
 version = "0.10.5"
+source = "git+https://github.com/zeyugao/zeroconf-rs#860b030064308d4318e2c6936886674d955c6472"
 dependencies = [
  "avahi-sys",
  "bonjour-sys",
@@ -1615,6 +1618,7 @@ dependencies = [
 [[package]]
 name = "zeroconf-macros"
 version = "0.1.2"
+source = "git+https://github.com/zeyugao/zeroconf-rs#860b030064308d4318e2c6936886674d955c6472"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/passthrough.rs"
 tokio = { version = "1.17.0", features = [ "full" ] }
 futures-util = { version = "0.3.21" }
 
-zeroconf = { version = "0.10.5", path = "../zeroconf-rs/zeroconf", optional = true }
-mdns = { version = "3.0.0", path = "../mdns" }
+zeroconf = { git = "https://github.com/zeyugao/zeroconf-rs", optional = true }
+mdns = "3.0.0"
 
 rusty_libimobiledevice = { version = "0.1.2", features = [ "static", "vendored" ] }
 plist_plus = { version = "0.2.1", features = [ "static", "vendored" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ futures-util = { version = "0.3.21" }
 zeroconf = { git = "https://github.com/zeyugao/zeroconf-rs", optional = true }
 mdns = "3.0.0"
 
-rusty_libimobiledevice = { version = "0.1.2", features = [ "static", "vendored" ] }
-plist_plus = { version = "0.2.1", features = [ "static", "vendored" ] }
+rusty_libimobiledevice = "0.1.2"
+plist_plus = "0.2.1"
 
 log = { version = "0.4.16" }
 env_logger = { version = "0.7.1" }
@@ -33,4 +33,7 @@ rusb = { version = "0.9.1", optional = true }
 libusb1-sys = { version = "0.6.2", optional = true }
 
 [features]
+default = [ "static", "vendored" ]
+static = [ "rusty_libimobiledevice/static", "plist_plus/static" ]
 usb = [ "libusb1-sys", "rusb" ]
+vendored = [ "rusty_libimobiledevice/vendored", "plist_plus/vendored" ]


### PR DESCRIPTION
Some fixes to let me [package this](https://git.dblsaiko.net/systems/tree/packages/misc/netmuxd.nix) without having to patch/use my fork.

- Update netmuxd version in Cargo.lock; don't forget to update (run cargo check) and commit this file too when changing the version!
- Fix crate paths (refers to local directory outside of repository)
- Vendored and static build as default features