### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idevice"
-version = "0.1.42"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eedb6dccf7ef24f7a5bc3f05af5f31c604951958256e05febc7efa4196d67856"
 dependencies = [
  "base64",
  "env_logger",
@@ -1174,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "netmuxd"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "colored",
  "crossfire",


### PR DESCRIPTION
I just cloned the repo and ran `cargo check`, this updated the Cargo.lock and properly pinned the `idevice` version. 